### PR TITLE
Use new versions and flags

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,24 +4,17 @@ plugins {
     kotlin("android")
 }
 
-group "com.kashif"
-version "1.0-SNAPSHOT"
-
-repositories {
-    jcenter()
-}
-
 dependencies {
     implementation(project(":common"))
     implementation("androidx.activity:activity-compose:1.6.1")
 }
 
 android {
-    compileSdkVersion(33)
+    compileSdk = 33
     defaultConfig {
         applicationId = "com.kashif.android"
-        minSdkVersion(24)
-        targetSdkVersion(33)
+        minSdk = 24
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0-SNAPSHOT"
     }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.compose.compose
-
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose")
@@ -78,11 +76,11 @@ kotlin {
 
 
 android {
-    compileSdkVersion(33)
+    compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdkVersion(24)
-        targetSdkVersion(33)
+        minSdk = 24
+        targetSdk = 33
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -54,7 +54,7 @@ kotlin {
                 api("androidx.core:core-ktx:1.9.0")
             }
         }
-        val androidTest by getting {
+        val androidUnitTest by getting {
             dependencies {
                 implementation("junit:junit:4.13.2")
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
-kotlin.native.enableDependencyPropagation=false
 android.useAndroidX=true
-kotlin.version=1.7.10
-agp.version=7.3.0
-compose.version=1.2.0
+kotlin.version=1.8.0
+agp.version=7.4.1
+compose.version=1.3.0
 org.jetbrains.compose.experimental.uikit.enabled=true
+kotlin.mpp.androidSourceSetLayoutVersion=2


### PR DESCRIPTION
1) The property 'kotlin.native.enableDependencyPropagation=false' has no effect in this and future Kotlin versions, as Kotlin/Native dependency commonization is now enabled by default. It is safe to remove the property.
2) Use new kotlin.mpp.androidSourceSetLayoutVersion
3) New Kotlin, Compose, AGP