### PR TITLE
Added Support for koin for DI

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="Embedded JDK" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.10" />
+    <option name="version" value="1.8.0" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="azul-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="azul-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
                 api(compose.runtime)
                 api(compose.foundation)
                 api(compose.material)
+                implementation(libs.koin.core)
             }
         }
         val commonTest by getting {
@@ -52,6 +53,7 @@ kotlin {
             dependencies {
                 api(libs.androidx.appcompat)
                 api(libs.androidx.coreKtx)
+                implementation(libs.koin.compose)
             }
         }
         val androidUnitTest by getting {
@@ -62,6 +64,7 @@ kotlin {
         val desktopMain by getting {
             dependencies {
                 api(compose.preview)
+                implementation(libs.koin.core)
             }
         }
         val desktopTest by getting

--- a/common/src/androidMain/kotlin/com/kashif/common/main/main.android.kt
+++ b/common/src/androidMain/kotlin/com/kashif/common/main/main.android.kt
@@ -4,6 +4,6 @@ import androidx.compose.runtime.Composable
 import com.kashif.common.App
 
 @Composable
-fun Application(){
-    App()
+fun Application() {
+    App(platform = "Android")
 }

--- a/common/src/androidMain/kotlin/com/kashif/common/platform.kt
+++ b/common/src/androidMain/kotlin/com/kashif/common/platform.kt
@@ -1,5 +1,7 @@
 package com.kashif.common
 
-actual fun getPlatformName(): String {
-    return "Android"
+import org.koin.dsl.module
+
+actual fun platformModule() = module {
+
 }

--- a/common/src/commonMain/kotlin/com/kashif/common/App.kt
+++ b/common/src/commonMain/kotlin/com/kashif/common/App.kt
@@ -13,13 +13,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-internal fun App() {
+internal fun App(platform: String) {
     var text by remember { mutableStateOf("Hello, World!") }
-    val platformName = getPlatformName()
 
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Button(onClick = {
-            text = "Hello, $platformName"
+            text = "Hello, $platform"
         }) {
             Text(text)
         }

--- a/common/src/commonMain/kotlin/com/kashif/common/Platform.kt
+++ b/common/src/commonMain/kotlin/com/kashif/common/Platform.kt
@@ -1,3 +1,5 @@
 package com.kashif.common
 
-expect fun getPlatformName(): String
+import org.koin.core.module.Module
+
+expect fun platformModule(): Module

--- a/common/src/commonMain/kotlin/com/kashif/common/di/Koin.kt
+++ b/common/src/commonMain/kotlin/com/kashif/common/di/Koin.kt
@@ -1,0 +1,32 @@
+package com.kashif.common.di
+
+import com.kashif.common.platformModule
+import org.koin.core.context.startKoin
+import org.koin.dsl.KoinAppDeclaration
+import org.koin.dsl.module
+
+fun initKoin(
+    enableNetworkLogs: Boolean = false,
+    baseUrl: String,
+    appDeclaration: KoinAppDeclaration = {},
+) = startKoin {
+    appDeclaration()
+    modules(commonModule(enableNetworkLogs = enableNetworkLogs, baseUrl))
+}
+
+// called by iOS, Desktop etc
+fun initKoin(baseUrl: String) = initKoin(enableNetworkLogs = true, baseUrl = baseUrl) {}
+
+fun commonModule(
+    enableNetworkLogs: Boolean,
+    baseUrl: String,
+) =   platformModule() + getDataModule(enableNetworkLogs, baseUrl)
+
+fun getDataModule(
+    enableNetworkLogs: Boolean,
+    baseUrl: String,
+) = module {
+
+
+
+}

--- a/common/src/desktopMain/kotlin/com/kashif/common/main.desktop.kt
+++ b/common/src/desktopMain/kotlin/com/kashif/common/main.desktop.kt
@@ -6,5 +6,5 @@ import androidx.compose.runtime.Composable
 @Preview
 @Composable
 fun Application() {
-    App()
+    App("Desktop")
 }

--- a/common/src/desktopMain/kotlin/com/kashif/common/platform.kt
+++ b/common/src/desktopMain/kotlin/com/kashif/common/platform.kt
@@ -1,5 +1,7 @@
 package com.kashif.common
 
-actual fun getPlatformName(): String {
-    return "Desktop"
+import org.koin.dsl.module
+
+actual fun platformModule() = module {
+
 }

--- a/common/src/iosMain/kotlin/com/kashif/common/Platform.kt
+++ b/common/src/iosMain/kotlin/com/kashif/common/Platform.kt
@@ -1,6 +1,8 @@
 package com.kashif.common
 
+import org.koin.dsl.module
 
-actual fun getPlatformName(): String {
-    return "Ios"
+
+actual fun platformModule()= module {
+
 }

--- a/common/src/iosMain/kotlin/com/kashif/common/ServiceProvider.kt
+++ b/common/src/iosMain/kotlin/com/kashif/common/ServiceProvider.kt
@@ -1,0 +1,7 @@
+package com.kashif.common
+
+import org.koin.core.component.KoinComponent
+
+object ServiceProvider : KoinComponent {
+
+}

--- a/common/src/iosMain/kotlin/com/kashif/common/main.ios.kt
+++ b/common/src/iosMain/kotlin/com/kashif/common/main.ios.kt
@@ -5,5 +5,5 @@ import platform.UIKit.UIViewController
 
 fun MainViewController(): UIViewController =
     Application("Example Application") {
-        App()
+        App("Ios")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 android.useAndroidX=true
 kotlin.version=1.8.0
-agp.version=7.4.1
+agp.version=7.4.0-beta02
 compose.version=1.3.0
 org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # https://github.com/JetBrains/compose-jb/blob/master/VERSIONING.md#kotlin-compatibility
 kotlin = "1.8.0" # https://kotlinlang.org/docs/releases.html#release-details
-agp = "7.4.1" # https://developer.android.com/studio/releases/gradle-plugin
+agp = "7.4.0-beta02" # https://developer.android.com/studio/releases/gradle-plugin
 compose = "1.3.0" # https://github.com/JetBrains/compose-jb
 
 coreKtx = "1.9.0" # https://developer.android.com/jetpack/androidx/releases/core
@@ -12,6 +12,9 @@ compileSdk = "33"
 minSdk = "24"
 targetSdk = "33"
 
+koin-version = "3.3.3"
+koin-compose-version = "3.4.2"
+
 
 [libraries]
 androidGradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -21,5 +24,8 @@ kotlinGradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.r
 androidx-coreKtx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
+
+koin-core = {module = "io.insert-koin:koin-core", version.ref = "koin-version"}
+koin-compose = {module = "io.insert-koin:koin-androidx-compose", version.ref = "koin-compose-version"}
 
 junit = "junit:junit:4.13.2"


### PR DESCRIPTION
Closes #5 

Koin is set up with separate platform modules for each target.

```
// Android
actual fun platformModule() = module {

}

```

```
// Desktop
actual fun platformModule() = module {

}
```
```
//IOS
object ServiceProvider : KoinComponent {

}
```
Koin does not work directly in ios. So, this is how we can use koin for ios specific dependencies